### PR TITLE
Cleanup and small stuff

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,0 +1,10 @@
+array_width          = 95
+attr_fn_like_width   = 120
+chain_width          = 120
+combine_control_expr = false
+comment_width        = 120
+edition              = "2021"
+max_width            = 120
+merge_imports        = true
+reorder_imports      = true
+use_small_heuristics = "Max"

--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,7 +1,6 @@
 array_width          = 95
 attr_fn_like_width   = 120
 chain_width          = 120
-combine_control_expr = false
 comment_width        = 120
 edition              = "2021"
 max_width            = 120

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 [dependencies]
 serenity = {version = "0.12.0", default-features = false, features = ["client", "gateway", "rustls_backend", "model", "cache"] }
 poise = { git = "https://github.com/serenity-rs/poise", branch = "current" }
-tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread", "signal"] }
 env_logger = "0.10.0"
 serde_yaml = "0.9.27"
 serde = "1.0.188"

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -51,7 +51,7 @@ pub async fn preview(
     if let Some(color) = CONFIG.colors.get(&choice) {
         let paths = [CreateAttachment::bytes(create_image(&color), format!("{choice}.png"))];
         ctx.channel_id().send_files(ctx.http(), paths, CreateMessage::new().content("")).await?;
-        ctx.say("Preview send").await?;
+        ctx.say("Preview sent").await?;
     } else {
         ctx.say("Unknown color ...").await?;
     }

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -8,8 +8,9 @@ use crate::{
 use poise::{
     futures_util::{Stream, StreamExt},
     serenity_prelude::futures,
+    CreateReply,
 };
-use serenity::builder::{CreateAttachment, CreateMessage};
+use serenity::builder::CreateAttachment;
 
 async fn autocomplete_name<'a>(_ctx: PoiseContext<'_>, partial: &'a str) -> impl Stream<Item = String> + 'a {
     futures::stream::iter(&CONFIG.colors)
@@ -50,8 +51,12 @@ pub async fn preview(
 ) -> Result<(), Error> {
     if let Some(color) = CONFIG.colors.get(&choice) {
         let paths = [CreateAttachment::bytes(create_image(&color), format!("{choice}.png"))];
-        ctx.channel_id().send_files(ctx.http(), paths, CreateMessage::new().content("")).await?;
-        ctx.say("Preview sent").await?;
+        ctx.send(CreateReply {
+            content: Some("Preview:".into()),
+            attachments: paths.to_vec().into(),
+            ..Default::default()
+        })
+        .await?;
     } else {
         ctx.say("Unknown color ...").await?;
     }

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -50,7 +50,6 @@ pub async fn preview(
 ) -> Result<(), Error> {
     if let Some(color) = CONFIG.colors.get(&choice) {
         let paths = [CreateAttachment::bytes(create_image(&color), format!("{choice}.png"))];
-
         ctx.channel_id().send_files(ctx.http(), paths, CreateMessage::new().content("")).await?;
         ctx.say("Preview send").await?;
     } else {

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1,14 +1,17 @@
 use crate::create::create_image;
 
-use poise::futures_util::Stream;
-use poise::futures_util::StreamExt;
-use poise::serenity_prelude::futures;
+use crate::{
+    config::CONFIG,
+    role::{process_color, random_color},
+    Error, PoiseContext,
+};
+use poise::{
+    futures_util::{Stream, StreamExt},
+    serenity_prelude::futures,
+};
 use serenity::builder::{CreateAttachment, CreateMessage};
-use crate::{Error, PoiseContext};
-use crate::role::{process_color, random_color};
-use crate::config::CONFIG;
 
-async fn autocomplete_name<'a>(_ctx: PoiseContext<'_>, partial: &'a str, ) -> impl Stream<Item = String> + 'a {
+async fn autocomplete_name<'a>(_ctx: PoiseContext<'_>, partial: &'a str) -> impl Stream<Item = String> + 'a {
     futures::stream::iter(&CONFIG.colors)
         .filter(move |(name, _)| futures::future::ready(name.starts_with(partial)))
         .map(|(name, _)| name.to_owned())
@@ -19,17 +22,17 @@ pub async fn color(
     ctx: PoiseContext<'_>,
     #[description = "The color you want"]
     #[autocomplete = "autocomplete_name"]
-    color_choice: Option<String>, ) -> Result<(), Error> {
-
+    color_choice: Option<String>,
+) -> Result<(), Error> {
     match color_choice {
         Some(choice) => {
-            if CONFIG.colors.contains_key(choice.as_str()) {
-                process_color(ctx, choice.to_string()).await?;
+            if CONFIG.colors.contains_key(&choice) {
+                process_color(ctx, &choice).await?;
                 ctx.say(format!("Assigned color {choice}")).await?;
             } else {
                 ctx.say("Unknown color ...").await?;
             }
-        },
+        }
         None => {
             random_color(&ctx.serenity_context(), &ctx.author_member().await.unwrap()).await?;
             ctx.say(format!("Assigned random color")).await?;
@@ -43,13 +46,10 @@ pub async fn preview(
     ctx: PoiseContext<'_>,
     #[description = "The preview you want to see"]
     #[autocomplete = "autocomplete_name"]
-    choice: String, ) -> Result<(), Error> {
-
-    if CONFIG.colors.contains_key(&choice) {
-        let color = CONFIG.colors[&choice];
-        let paths = [
-            CreateAttachment::bytes(create_image(&color), format!("{choice}.png"))
-        ];
+    choice: String,
+) -> Result<(), Error> {
+    if let Some(color) = CONFIG.colors.get(&choice) {
+        let paths = [CreateAttachment::bytes(create_image(&color), format!("{choice}.png"))];
 
         ctx.channel_id().send_files(ctx.http(), paths, CreateMessage::new().content("")).await?;
         ctx.say("Preview send").await?;
@@ -62,10 +62,13 @@ pub async fn preview(
 
 #[poise::command(prefix_command, slash_command)]
 pub async fn help(ctx: PoiseContext<'_>) -> Result<(), Error> {
-    ctx.say("Help for Color-Bot
+    ctx.say(
+        "Help for Color-Bot
             `<<color`   [Assign a random color]
             `<<color ColorName`   [Assign the specified color]
-            `<<preview ColorName`   [Send a preview image]").await?;
+            `<<preview ColorName`   [Send a preview image]",
+    )
+    .await?;
 
     Ok(())
 }

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1,10 +1,10 @@
-use crate::create::create_image;
-
 use crate::{
     config::CONFIG,
+    create::create_image,
     role::{process_color, random_color},
     Error, PoiseContext,
 };
+
 use poise::{
     futures_util::{Stream, StreamExt},
     serenity_prelude::futures,

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -49,18 +49,18 @@ pub async fn preview(
     #[autocomplete = "autocomplete_name"]
     choice: String,
 ) -> Result<(), Error> {
-    if let Some(color) = CONFIG.colors.get(&choice) {
-        let paths = [CreateAttachment::bytes(create_image(&color), format!("{choice}.png"))];
-        ctx.send(CreateReply {
-            content: Some("Preview:".into()),
-            attachments: paths.to_vec().into(),
-            ..Default::default()
-        })
-        .await?;
-    } else {
-        ctx.say("Unknown color ...").await?;
+    match CONFIG.colors.get(&choice) {
+        Some(color) => {
+            let paths = [CreateAttachment::bytes(create_image(&color), format!("{choice}.png"))];
+            ctx.send(CreateReply {
+                content: Some("Preview:".into()),
+                attachments: paths.to_vec().into(),
+                ..Default::default()
+            })
+            .await?;
+        },
+        None => ctx.say("Unknown color ...").await?,
     }
-
     Ok(())
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -6,11 +6,11 @@ use std::collections::HashMap;
 pub struct Config {
     #[serde(alias = "BotToken")]
     pub bot_token: String,
-    #[serde(alias = "InviteLink")]
+    #[serde(alias = "InviteLink", default)]
     pub invite_link: String,
-    #[serde(alias = "AutoKickOnServer")]
+    #[serde(alias = "AutoKickOnServer", default)]
     pub auto_kick: HashMap<String, String>,
-    #[serde(alias = "Admins")]
+    #[serde(alias = "Admins", default)]
     pub admins: HashMap<String, String>,
     #[serde(alias = "Colors")]
     pub colors: HashMap<String, u64>,

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,6 @@
-use std::collections::HashMap;
 use lazy_static::lazy_static;
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub struct Config {
@@ -13,7 +13,7 @@ pub struct Config {
     #[serde(alias = "Admins")]
     pub admins: HashMap<String, String>,
     #[serde(alias = "Colors")]
-    pub colors: HashMap<String, u64>
+    pub colors: HashMap<String, u64>,
 }
 
 lazy_static! {

--- a/src/create.rs
+++ b/src/create.rs
@@ -7,7 +7,7 @@ pub fn create_image(color: &u64) -> Vec<u8> {
 
     let mut imgbuf = image::ImageBuffer::new(200, 100);
     for (_, _, pixel) in imgbuf.enumerate_pixels_mut() {
-        *pixel = image::Rgb([red,green,blue]);
+        *pixel = image::Rgb([red, green, blue]);
     }
 
     let mut bytes: Vec<u8> = Vec::new();

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,13 +7,12 @@ mod role;
 
 use crate::{config::CONFIG, role::random_color};
 
+use poise::serenity_prelude as serenity;
 use serenity::{
     all::{ActivityData, ClientBuilder, GatewayIntents, Permissions},
     builder::{CreateMessage, EditRole},
 };
 use std::{sync::Arc, time::Duration};
-
-use poise::serenity_prelude as serenity;
 
 type Error = Box<dyn std::error::Error + Send + Sync>;
 type PoiseContext<'a> = poise::Context<'a, Data, Error>;

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,19 +43,19 @@ async fn event_handler(
     _: &Data,
 ) -> Result<(), Error> {
     match event {
-        serenity::FullEvent::Ready { data_about_bot, .. } => unsafe {
+        serenity::FullEvent::Ready { data_about_bot, .. } => {
             println!("Logged in as {}", data_about_bot.user.name);
             ctx.set_activity(Some(ActivityData::playing("Perfect Color!")));
 
-            if FIRST_TIME {
+            if unsafe { FIRST_TIME } {
                 for guild in ctx.cache.guilds() {
                     let existing_roles: Vec<String> = guild.roles(&ctx.http).await?.values().map(|role| role.name.clone()).collect();
-                    for (name, color) in &CONFIG.colors {
+                    for (name, &color) in &CONFIG.colors {
                         if existing_roles.contains(name) {
                             continue;
                         }
 
-                        let r = EditRole::new().name(name).colour(color.clone()).permissions(Permissions::empty());
+                        let r = EditRole::new().name(name).colour(color).permissions(Permissions::empty());
                         match guild.create_role(&ctx.http, r).await {
                             Ok(_) => {}
                             Err(e) => {
@@ -65,21 +65,16 @@ async fn event_handler(
                         };
                     }
                 }
-                FIRST_TIME = false;
+                unsafe { FIRST_TIME = false; }
             }
             println!("Bot is ready")
         }
         serenity::FullEvent::GuildMemberAddition { new_member } => {
-            match random_color(&ctx, &new_member).await {
-                Ok(_) => {}
-                Err(e) => {
-                    println!("Error while member join, {}", e);
-                    return Ok(())
-                }
+            if let Err(e) = random_color(&ctx, &new_member).await {
+                return Ok(println!("Error while member join, {}", e));
             }
-            if !CONFIG.auto_kick.contains_key(new_member.guild_id.to_string().as_str()) {
-                println!("Server not in kick list");
-                return Ok(())
+            if !CONFIG.auto_kick.contains_key(&new_member.guild_id.to_string()) {
+                return Ok(println!("Server not in kick list"));
             }
 
             tokio::time::sleep(Duration::from_secs(30 * 60)).await;
@@ -87,34 +82,20 @@ async fn event_handler(
             match new_member.roles(&ctx.cache) {
                 Some(roles) => {
                     for role in roles {
-                        if CONFIG.colors.contains_key(role.name.as_str()) {
-                            continue;
-                        } else {
-                            // User has at least one role that isn't a color
-                            return Ok(())
+                        if !CONFIG.colors.contains_key(role.name.as_str()) {
+                            return Ok(());
                         }
                     }
                 },
-                None => {
-                    eprintln!("Unable to retrieve roles from cache");
-                    return Ok(())
-                }
+                None => return Ok(eprintln!("Unable to retrieve roles from cache"))
             }
 
-            match new_member.user.dm(&ctx.http, CreateMessage::new().content(format!("You got kicked from the server.\nPlease read the welcome channel for more information\n{}", CONFIG.invite_link))).await {
-                Ok(_) => {},
-                Err(e) => {
-                    println!("Unable to message user in private chat, {}", e);
-                    return Ok(())
-                }
+            if let Err(e) = new_member.user.dm(&ctx.http, CreateMessage::new().content(format!("You got kicked from the server.\nPlease read the welcome channel for more information\n{}", CONFIG.invite_link))).await {
+                    return Ok(println!("Unable to message user in private chat, {}", e));
             };
 
-            match new_member.kick_with_reason(&ctx.http, "User hasn't picked a role after 30 minutes").await {
-                Ok(_) => {},
-                Err(e) => {
-                    println!("Unable to kick user after 30 minutes, {}", e);
-                    return Ok(())
-                }
+            if let Err(e) = new_member.kick_with_reason(&ctx.http, "User hasn't picked a role after 30 minutes").await {
+                return Ok(println!("Unable to kick user after 30 minutes, {}", e));
             }
         }
         _ => {}
@@ -127,11 +108,10 @@ async fn main() {
     env_logger::init();
 
     if CONFIG.bot_token == "YOUR_BOT_TOKEN" {
-        eprintln!("Your bot token is still the default, please change it in the config.yaml");
-        return;
+        return eprintln!("Your bot token is still the default, please change it in the config.yaml");
     }
 
-    let intents = GatewayIntents::non_privileged() | GatewayIntents::MESSAGE_CONTENT | GatewayIntents::GUILD_MEMBERS;
+    let intents = GatewayIntents::all() ^ GatewayIntents::GUILD_PRESENCES;
     let options = poise::FrameworkOptions {
         commands: vec![commands::color(), commands::preview(), commands::help()],
         prefix_options: poise::PrefixFrameworkOptions {
@@ -150,16 +130,29 @@ async fn main() {
     let framework = poise::Framework::builder()
         .setup(move |ctx, _ready, framework| {
             Box::pin(async move {
-                poise::builtins::register_globally(ctx, &framework.options().commands).await?;
-                Ok(Data {})
+                poise::builtins::register_globally(ctx, &framework.options().commands)
+                .await
+                .map_err(|e| e.into())
+                .map(|_| Data {})
             })
         })
         .options(options)
         .build();
 
-    let client = ClientBuilder::new(CONFIG.bot_token.as_str(), intents)
+    let mut client = ClientBuilder::new(&CONFIG.bot_token, intents)
         .framework(framework)
-        .await;
+        .await
+        .expect("Couldn't build a bot client!");
 
-    client.unwrap().start().await.unwrap();
+    let shards = client.shard_manager.clone();
+    tokio::spawn(async move {
+        if let Ok(_) = tokio::signal::ctrl_c().await {
+            shards.shutdown_all().await;
+        }
+    });
+
+    if let Err(e) = client.start().await {
+        println!("Bot crashed on {e:?}");
+        client.shard_manager.shutdown_all().await
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -122,7 +122,7 @@ async fn main() {
         return eprintln!("Your bot token is still the default, please change it in the config.yaml");
     }
 
-    let intents = GatewayIntents::all() ^ GatewayIntents::GUILD_PRESENCES;
+    let intents = GatewayIntents::non_privileged() | GatewayIntents::MESSAGE_CONTENT | GatewayIntents::GUILD_MEMBERS;
     let options = poise::FrameworkOptions {
         commands: vec![commands::color(), commands::preview(), commands::help()],
         prefix_options: poise::PrefixFrameworkOptions {

--- a/src/role.rs
+++ b/src/role.rs
@@ -14,13 +14,12 @@ fn rand_hash<K: Eq + Hash, V>(hash: &HashMap<K, V>) -> &K {
 }
 
 pub async fn random_color(ctx: &Context, member: &Member) -> Result<(), Error> {
-    let choice = rand_hash(&CONFIG.colors);
-
     let guild = match member.guild_id.to_guild_cached(&ctx.cache) {
         Some(g) => g.clone(),
         None => return Ok(()),
     };
 
+    let choice = rand_hash(&CONFIG.colors);
     let r = EditRole::new().name(choice).colour(CONFIG.colors[choice]).permissions(Permissions::empty());
     let role_id = match guild.role_by_name(choice) {
         Some(role) => role.id,
@@ -29,11 +28,8 @@ pub async fn random_color(ctx: &Context, member: &Member) -> Result<(), Error> {
 
     match member.roles(&ctx.cache) {
         Some(roles) => {
-            for role in roles {
-                if CONFIG.colors.contains_key(role.name.as_str()) {
-                    member.remove_role(ctx.http(), role.id).await?;
-                    break;
-                }
+            for role in roles.iter().filter(|role| CONFIG.colors.contains_key(&role.name)) {
+                member.remove_role(ctx.http(), role.id).await?
             }
         }
         None => {}
@@ -57,11 +53,8 @@ pub async fn process_color(ctx: PoiseContext<'_>, choice: &str) -> Result<(), Er
     let m = ctx.author_member().await.unwrap();
     match m.roles(ctx.cache()) {
         Some(roles) => {
-            for role in roles {
-                if CONFIG.colors.contains_key(role.name.as_str()) {
-                    m.remove_role(ctx.http(), role.id).await?;
-                    break;
-                }
+            for role in roles.iter().filter(|role| CONFIG.colors.contains_key(&role.name)) {
+                m.remove_role(ctx.http(), role.id).await?;
             }
         }
         None => {}

--- a/src/role.rs
+++ b/src/role.rs
@@ -1,14 +1,13 @@
-use crate::{Error, PoiseContext};
-use crate::config::CONFIG;
+use crate::{config::CONFIG, Error, PoiseContext};
 
-use std::collections::HashMap;
-use std::hash::Hash;
-use rand::thread_rng;
-use serenity::http::CacheHttp;
-use rand::seq::IteratorRandom;
-use serenity::all::{Member, Permissions};
-use serenity::builder::EditRole;
-use serenity::prelude::Context;
+use rand::{seq::IteratorRandom, thread_rng};
+use serenity::{
+    all::{Member, Permissions},
+    builder::EditRole,
+    http::CacheHttp,
+    prelude::Context,
+};
+use std::{collections::HashMap, hash::Hash};
 
 fn rand_hash<K: Eq + Hash, V>(hash: &HashMap<K, V>) -> &K {
     hash.keys().choose(&mut thread_rng()).unwrap()
@@ -19,13 +18,13 @@ pub async fn random_color(ctx: &Context, member: &Member) -> Result<(), Error> {
 
     let guild = match member.guild_id.to_guild_cached(&ctx.cache) {
         Some(g) => g.clone(),
-        None => return Ok(())
+        None => return Ok(()),
     };
 
     let r = EditRole::new().name(choice).colour(CONFIG.colors[choice]).permissions(Permissions::empty());
     let role_id = match guild.role_by_name(choice) {
         Some(role) => role.id,
-        None => guild.create_role(&ctx.http, r).await.unwrap().id
+        None => guild.create_role(&ctx.http, r).await.unwrap().id,
     };
 
     match member.roles(&ctx.cache) {
@@ -43,16 +42,16 @@ pub async fn random_color(ctx: &Context, member: &Member) -> Result<(), Error> {
     Ok(member.add_role(&ctx.http, role_id).await?)
 }
 
-pub async fn process_color(ctx: PoiseContext<'_>, choice: String) -> Result<(), Error> {
+pub async fn process_color(ctx: PoiseContext<'_>, choice: &str) -> Result<(), Error> {
     let guild = match ctx.guild() {
         Some(guild) => guild.clone(),
-        None => return Ok(eprintln!("Can't find server ..."))
+        None => return Ok(eprintln!("Can't find server ...")),
     };
 
-    let r = EditRole::new().name(&choice).colour(CONFIG.colors[&choice]).permissions(Permissions::empty());
-    let role_id = match guild.role_by_name(&choice) {
+    let r = EditRole::new().name(choice).colour(CONFIG.colors[choice]).permissions(Permissions::empty());
+    let role_id = match guild.role_by_name(choice) {
         Some(role) => role.id,
-        None => guild.create_role(ctx.http(), r).await?.id
+        None => guild.create_role(ctx.http(), r).await?.id,
     };
 
     let m = ctx.author_member().await.unwrap();


### PR DESCRIPTION
As discussed in Discord, small PR to clean some stuff.
- `if x.is_some() { x.unwrap() ...` into more idiomatic alternatives such as matches and if-let chains.
- Also added a `.rustfmt.toml` to keep formatting about the same as it was in terms of width, allowing for automatically grouping and sorting `use` statements.
- Added a ctrl-c handler to cleanly shut the bot down.
- Changed `process_color` to take a `&str` so fewer cloning is required, and replaced clones with borrows in other places where that's allowed.

Will convert the draft PR to a normal PR as soon as I've done some more manual testing to see if everything works as expected.